### PR TITLE
Global prisma instance

### DIFF
--- a/app/page.jsx
+++ b/app/page.jsx
@@ -1,3 +1,19 @@
-export default function Page() {
-  return <h1>Hello, Next.js!</h1>;
+// use the global prisma instance defined in lib/prisma.js
+// instead of  import { PrismaClient } from '@prisma/client';
+// which would create a new instance of PrismaClient
+import { prisma } from "../lib/prisma";
+
+export default async function Page() {
+  // just testing out the usage of prisma in a page
+  const employee = await prisma.employee.findUnique({
+    where: {
+      // usernames are marked as unique in the schema
+      // so using findUnique is safe
+      username: "chrisdas",
+    },
+  });
+
+  console.log({ employee });
+  // use the main as the outermost tag
+  return <main>Hello, {employee?.firstName}</main>;
 }

--- a/lib/prisma.js
+++ b/lib/prisma.js
@@ -1,0 +1,17 @@
+import { PrismaClient } from '@prisma/client';
+
+// Attach PrismaClient to the global object to prevent exhausting the database connection limit in development
+
+const globalForPrisma = global;
+
+// check the global object to see if prisma has already been attached
+// if it does, use the existing prisma instance
+const prisma = globalForPrisma.prisma || 
+// if it doesn't, create a new prisma instance
+new PrismaClient({
+    log: ['query'],
+});
+
+if (process.env.NODE_ENV !== 'production') globalForPrisma.prisma = prisma;
+
+export { prisma };

--- a/package.json
+++ b/package.json
@@ -8,8 +8,10 @@
     "build": "prisma generate && next build",
     "start": "next start",
     "lint": "next lint",
-    "seed": "node prisma/seed.js",
     "generate": "prisma generate"
+  },
+  "prisma" : {
+    "seed": "node prisma/seed.js"
   },
   "dependencies": {
     "@prisma/client": "^5.14.0",


### PR DESCRIPTION
set up a global prisma instance

check if a prisma instance exists. if not, create one and use it. 

this will prevent creating too many prisma instances