### PR TITLE
trucksheet alert fix

### DIFF
--- a/app/(home)/trucksheet/form.tsx
+++ b/app/(home)/trucksheet/form.tsx
@@ -99,7 +99,7 @@ export default function TruckSheetForm() {
       return;
     }
 
-    if (!noMilageEntered) {
+    if (!mileage) {
       setNoMilageEntered("Please enter the mileage");
       setTimeout(() => {
         setNoMilageEntered(null);


### PR DESCRIPTION
- I was checking if NoMileageEntered was false instead of mileage.

- This caused the alert for not having a mileage value to always appear on submit, even if you entered a value.