### PR TITLE
table scroll fix

### DIFF
--- a/app/(home)/drivers/driverTable.css
+++ b/app/(home)/drivers/driverTable.css
@@ -7,13 +7,6 @@
   background-color: rgba(25, 118, 210, 0.12);
 }
 
-/* #driver-table-head-cell {
-  background-color: rgb(37, 40, 45);
-  color: white;
-  border-top: 2px solid rgba(9, 159, 255, 0.5);
-  border-bottom: 2px solid rgba(9, 159, 255, 0.5);
-} */
-
 .driver-subtitle {
   flex: 1 1 100%;
   color: white;
@@ -33,10 +26,6 @@
   margin-bottom: 1.5%;
   background-color: rgb(37, 40, 45);
   border-radius: 5px;
-}
-
-.driver-tableContainer {
-  max-height: 80.5vh;
 }
 
 .driver-table-row {

--- a/app/(home)/office/officeEmployeeTable.css
+++ b/app/(home)/office/officeEmployeeTable.css
@@ -27,10 +27,6 @@
   border-radius: 5px;
 }
 
-.officeEmployee-tableContainer {
-  max-height: 80.5vh;
-}
-
 .officeEmployee-table-row {
   cursor: pointer;
 }

--- a/app/(home)/trucks/truckTable.css
+++ b/app/(home)/trucks/truckTable.css
@@ -42,10 +42,6 @@
   max-width: 3vw;
 }
 
-.truck-tableContainer {
-  max-height: 80.5vh;
-}
-
 .truck-table-row {
   cursor: pointer;
 }


### PR DESCRIPTION
-remove max-height from the table containers of each page.

-This will allow the table to grow in the page and we can just use the page scroll instead of table scroll.